### PR TITLE
Fix incorrect path suggestion

### DIFF
--- a/plato/example/config/parser/Parse_DSTC2.yaml
+++ b/plato/example/config/parser/Parse_DSTC2.yaml
@@ -3,6 +3,6 @@
 package: plato.utilities.parser.parse_dstc2
 class: Parser
 arguments:
-  data_path: <path to where the DSTC2 data was unzipped>/data
+  data_path: <path to where the DSTC2 data was unzipped>
   ontology: plato/example/domains/CamRestaurants-rules.json
   database: plato/example/domains/CamRestaurants-dbase.db


### PR DESCRIPTION
Pointing to `<path to where the DSTC2 data was unzipped>/data` does not work.